### PR TITLE
Deploy/heroku

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: gunicorn TheUBD.wsgi --log-file -

--- a/procfile
+++ b/procfile
@@ -1,1 +1,0 @@
-web: gunicorn TheUBD.wsgi --log-file -


### PR DESCRIPTION
procfile의 미스 케이스드 덕분에 생긴 오류 해결